### PR TITLE
[WIP] Add identity handling in mq events

### DIFF
--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.helpers.api_utils import do_request
 from tests.helpers.api_utils import HOST_URL
+from tests.helpers.api_utils import MockSystemIdentity
 from tests.helpers.api_utils import MockUserIdentity
 from tests.helpers.api_utils import USER_IDENTITY
 
@@ -137,4 +138,11 @@ def enable_rbac(inventory_config):
 def user_identity_mock(flask_app):
     flask_app.user_identity = MockUserIdentity()
     yield flask_app.user_identity
+    # flask_app.user_identity = None
+
+
+@pytest.fixture(scope="function")
+def system_identity_mock(flask_app):
+    flask_app.system_identity = MockSystemIdentity()
+    yield flask_app.system_identity
     # flask_app.user_identity = None

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -14,14 +14,15 @@ from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import get_staleness_timestamps
 from tests.helpers.test_utils import minimal_host
 from tests.helpers.test_utils import now
+from tests.helpers.test_utils import SYSTEM_IDENTITY
 
 
 @pytest.fixture(scope="function")
 def mq_create_or_update_host(flask_app, event_producer_mock):
     def _mq_create_or_update_host(
-        host_data, platform_metadata=None, return_all_data=False, event_producer=event_producer_mock
+        host_data, identity, platform_metadata=None, return_all_data=False, event_producer=event_producer_mock
     ):
-        message = wrap_message(host_data.data(), platform_metadata=platform_metadata)
+        message = wrap_message(host_data.data(), identity, platform_metadata=platform_metadata)
         handle_message(json.dumps(message), event_producer)
         event = json.loads(event_producer.event)
 
@@ -42,7 +43,8 @@ def mq_create_three_specific_hosts(mq_create_or_update_host):
         host = minimal_host(
             insights_id=generate_uuid(), display_name=f"host{i}", fqdn=fqdn, facts=FACTS, tags=TAGS[i - 1]
         )
-        created_host = mq_create_or_update_host(host)
+
+        created_host = mq_create_or_update_host(host, SYSTEM_IDENTITY)
         created_hosts.append(created_host)
 
     return created_hosts
@@ -52,7 +54,7 @@ def mq_create_three_specific_hosts(mq_create_or_update_host):
 def mq_create_four_specific_hosts(mq_create_three_specific_hosts, mq_create_or_update_host):
     created_hosts = mq_create_three_specific_hosts
     host = minimal_host(insights_id=generate_uuid(), display_name=created_hosts[0].display_name)
-    created_host = mq_create_or_update_host(host)
+    created_host = mq_create_or_update_host(host, SYSTEM_IDENTITY)
     created_hosts.append(created_host)
 
     return created_hosts
@@ -66,7 +68,7 @@ def mq_create_hosts_in_all_states(mq_create_or_update_host):
         host = minimal_host(
             insights_id=generate_uuid(), stale_timestamp=timestamp.isoformat(), reporter="some reporter", facts=FACTS
         )
-        created_hosts[state] = mq_create_or_update_host(host)
+        created_hosts[state] = mq_create_or_update_host(host, SYSTEM_IDENTITY)
 
     return created_hosts
 

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -444,7 +444,7 @@ class MockSystemIdentity:
         self.is_trusted_system = False
         self.account_number = "test"
         self.identity_type = "System"
-        self.system = {"cert_type": "system", "cn": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}
+        self.system = {"cert_type": "system", "cn": "1b36b20f-7fa0-4454-a6d2-008294e06378"}
 
     def assert_called_once_with(self, identity, param, value):
         return True

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -58,11 +58,13 @@ class MockFuture:
         self._fire(self.errbacks)
 
 
-def wrap_message(host_data, operation="add_host", platform_metadata=None):
+def wrap_message(host_data, identity, operation="add_host", platform_metadata=None):
     message = {"operation": operation, "data": host_data}
 
     if platform_metadata:
         message["platform_metadata"] = platform_metadata
+    if identity:
+        message["identity"] = identity
 
     return message
 

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -18,7 +18,7 @@ SYSTEM_IDENTITY = {
     "account_number": "test",
     "auth_type": "cert-auth",
     "internal": {"auth_time": 6300, "org_id": "3340851"},
-    "system": {"cert_type": "system", "cn": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"},
+    "system": {"cert_type": "system", "cn": "1b36b20f-7fa0-4454-a6d2-008294e06378"},
     "type": "System",
 }
 USER_IDENTITY = {

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -33,6 +33,7 @@ from tests.helpers.db_utils import update_host_in_db
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import minimal_host
 from tests.helpers.test_utils import now
+from tests.helpers.test_utils import SYSTEM_IDENTITY
 
 
 def test_query_all(mq_create_three_specific_hosts, api_get, subtests):
@@ -585,7 +586,7 @@ def test_get_host_with_unescaped_special_characters(tag_query, mq_create_or_upda
     ]
 
     host = minimal_host(tags=tags)
-    created_host = mq_create_or_update_host(host)
+    created_host = mq_create_or_update_host(host, SYSTEM_IDENTITY)
 
     url = build_hosts_url(query=f"?tags={quote(tag_query)}")
     response_status, response_data = api_get(url)
@@ -605,7 +606,7 @@ def test_get_host_with_escaped_special_characters(namespace, key, value, mq_crea
     ]
 
     host = minimal_host(tags=tags)
-    created_host = mq_create_or_update_host(host)
+    created_host = mq_create_or_update_host(host, SYSTEM_IDENTITY)
 
     tags_query = quote(f"{quote_everything(namespace)}/{quote_everything(key)}={quote_everything(value)}")
     url = build_hosts_url(query=f"?tags={tags_query}")
@@ -851,11 +852,13 @@ def test_only_order_how(mq_create_three_specific_hosts, api_get, subtests):
             assert response_status == 400
 
 
-def test_get_hosts_only_insights(mq_create_three_specific_hosts, mq_create_or_update_host, api_get):
+def test_get_hosts_only_insights(
+    mq_create_three_specific_hosts, mq_create_or_update_host, api_get, system_identity_mock
+):
     created_hosts_with_insights_id = mq_create_three_specific_hosts
 
     host_without_insights_id = minimal_host(subscription_manager_id=generate_uuid())
-    created_host_without_insights_id = mq_create_or_update_host(host_without_insights_id)
+    created_host_without_insights_id = mq_create_or_update_host(host_without_insights_id, SYSTEM_IDENTITY)
 
     url = build_hosts_url(query="?registered_with=insights")
     response_status, response_data = api_get(url)

--- a/tests/test_culling.py
+++ b/tests/test_culling.py
@@ -20,6 +20,7 @@ from tests.helpers.mq_utils import assert_delete_event_is_valid
 from tests.helpers.test_utils import get_staleness_timestamps
 from tests.helpers.test_utils import minimal_host
 from tests.helpers.test_utils import now
+from tests.helpers.test_utils import SYSTEM_IDENTITY
 
 
 def test_with_stale_timestamp(mq_create_or_update_host, api_get):
@@ -28,10 +29,10 @@ def test_with_stale_timestamp(mq_create_or_update_host, api_get):
 
     host = minimal_host(fqdn="matching fqdn", stale_timestamp=stale_timestamp.isoformat(), reporter=reporter)
 
-    created_host = mq_create_or_update_host(host)
+    created_host = mq_create_or_update_host(host, SYSTEM_IDENTITY)
     assert_system_culling_data(created_host.data(), stale_timestamp, reporter)
 
-    updated_host = mq_create_or_update_host(host)
+    updated_host = mq_create_or_update_host(host, SYSTEM_IDENTITY)
     assert_system_culling_data(updated_host.data(), stale_timestamp, reporter)
 
     response_status, response_data = api_get(HOST_URL)
@@ -269,7 +270,7 @@ def test_stale_warning_timestamp(
 
     stale_timestamp = now() + timedelta(hours=1)
     host = minimal_host(stale_timestamp=stale_timestamp.isoformat())
-    created_host = mq_create_or_update_host(host)
+    created_host = mq_create_or_update_host(host, SYSTEM_IDENTITY)
 
     url = build_hosts_url(created_host.id)
     response_status, response_data = api_get(url)
@@ -292,7 +293,7 @@ def test_culled_timestamp(
 
     stale_timestamp = now() + timedelta(hours=1)
     host = minimal_host(stale_timestamp=stale_timestamp.isoformat())
-    created_host = mq_create_or_update_host(host)
+    created_host = mq_create_or_update_host(host, SYSTEM_IDENTITY)
 
     url = build_hosts_url(created_host.id)
     response_status, response_data = api_get(url)

--- a/tests/test_system_profile.py
+++ b/tests/test_system_profile.py
@@ -24,6 +24,7 @@ from tests.helpers.mq_utils import wrap_message
 from tests.helpers.system_profile_utils import system_profile_specification
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import minimal_host
+from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import valid_system_profile
 
 
@@ -31,7 +32,7 @@ from tests.helpers.test_utils import valid_system_profile
 def test_system_profile_includes_owner_id(mq_create_or_update_host, api_get, subtests):
     system_profile = valid_system_profile()
     host = minimal_host(system_profile=system_profile)
-    created_host = mq_create_or_update_host(host)
+    created_host = mq_create_or_update_host(host, SYSTEM_IDENTITY)
 
     url = build_system_profile_url(host_list_or_id=created_host.id)
 
@@ -215,7 +216,7 @@ def test_validate_sp_for_branch(mocker):
     config = Config(RuntimeEnvironment.SERVICE)
     tp = TopicPartition(config.host_ingress_topic, 0)
     fake_consumer.poll.return_value = {
-        tp: [SimpleNamespace(value=json.dumps(wrap_message(minimal_host().data()))) for _ in range(5)]
+        tp: [SimpleNamespace(value=json.dumps(wrap_message(minimal_host().data(), SYSTEM_IDENTITY))) for _ in range(5)]
     }
     fake_consumer.offsets_for_times.return_value = {tp: SimpleNamespace(offset=0)}
 
@@ -250,7 +251,7 @@ def test_validate_sp_for_missing_branch_or_repo(api_post, mocker):
     config = Config(RuntimeEnvironment.SERVICE)
     tp = TopicPartition(config.host_ingress_topic, 0)
     fake_consumer.poll.return_value = {
-        tp: [SimpleNamespace(value=json.dumps(wrap_message(minimal_host().data()))) for _ in range(5)]
+        tp: [SimpleNamespace(value=json.dumps(wrap_message(minimal_host().data(), SYSTEM_IDENTITY))) for _ in range(5)]
     }
     fake_consumer.offsets_for_times.return_value = {tp: SimpleNamespace(offset=0)}
 

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -6,6 +6,15 @@ from datetime import timedelta
 from datetime import timezone
 
 
+SYSTEM_IDENTITY = {
+    "account_number": "test",
+    "auth_type": "cert-auth",
+    "internal": {"auth_time": 6300, "org_id": "3340851"},
+    "system": {"cert_type": "system", "cn": "1b36b20f-7fa0-4454-a6d2-008294e06378"},
+    "type": "System",
+}
+
+
 def rpm_list():
     return [
         "rpm-python-4.11.3-32.el7.x86_64",
@@ -373,7 +382,8 @@ def rpm_list():
 
 def create_system_profile():
     return {
-        "owner_id": "1b36b20f-7fa0-4454-a6d2-008294e06378",
+        # "owner_id": "1b36b20f-7fa0-4454-a6d2-008294e06378",
+        "owner_id": SYSTEM_IDENTITY["system"]["cn"],
         "number_of_cpus": 1,
         "number_of_sockets": 2,
         "cores_per_socket": 4,
@@ -545,6 +555,7 @@ def build_mq_payload(payload_builder=build_host_chunk):
     message = {
         "operation": "add_host",
         "platform_metadata": {"request_id": random_uuid(), "archive_url": "http://s3.aws.com/redhat/insights/1234567"},
+        "identity": SYSTEM_IDENTITY,
         "data": build_host_payload(payload_builder),
     }
     return json.dumps(message).encode("utf-8")


### PR DESCRIPTION
## Overview

This WIP PR has been created for sharing thoughts how owner_id will be added for hosts coming in from Kafka

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
