### PR TITLE
Unit test fixes

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -452,23 +452,21 @@ class ConfigTestCase(TestCase):
                 self.assertEqual(config.kafka_producer[param], expected_value)
 
 
-@patch("app.db.get_engine")
+@patch("app.db.init_app")
 @patch("app.Config", **{"return_value.mgmt_url_path_prefix": "/", "return_value.unleash_token": ""})
 class CreateAppConfigTestCase(TestCase):
-    def test_config_is_assigned(self, config, get_engine):
-        # def test_config_is_assigned(self, get_engine):
+    def test_config_is_assigned(self, config, init_app):
         application = create_app(RuntimeEnvironment.TEST)
         self.assertIn("INVENTORY_CONFIG", application.app.config)
         self.assertEqual(config.return_value, application.app.config["INVENTORY_CONFIG"])
-        # self.assertEqual(type(application.app.config["INVENTORY_CONFIG"]), Config)
 
 
 @patch("app.connexion.FlaskApp")
 # @patch("app.connexion.apps.flask.FlaskApp")
-@patch("app.db.get_engine")
+@patch("app.db.init_app")
 class CreateAppConnexionAppInitTestCase(TestCase):
     @patch("app.TranslatingParser")
-    def test_specification_is_provided(self, translating_parser, get_engine, app):
+    def test_specification_is_provided(self, translating_parser, init_app, app):
         create_app(RuntimeEnvironment.TEST)
 
         translating_parser.assert_called_once_with(SPECIFICATION_FILE)
@@ -479,7 +477,7 @@ class CreateAppConnexionAppInitTestCase(TestCase):
         assert len(args) == 1
         assert args[0] is translating_parser.return_value.specification
 
-    def test_specification_is_parsed(self, get_engine, app):
+    def test_specification_is_parsed(self, init_app, app):
         create_app(RuntimeEnvironment.TEST)
         app.return_value.add_api.assert_called_once()
         args = app.return_value.add_api.mock_calls[0].args
@@ -488,7 +486,7 @@ class CreateAppConnexionAppInitTestCase(TestCase):
 
     # Test here the parsing is working with the referenced schemas from system_profile.spec.yaml
     # and the check parser.specification["components"]["schemas"] - this is more a library test
-    def test_translatingparser(self, get_engine, app):
+    def test_translatingparser(self, init_app, app):
         create_app(RuntimeEnvironment.TEST)
         # Check whether SystemProfileNetworkInterface is inside the schemas section
         # add_api uses the specification as firts argument
@@ -500,7 +498,7 @@ class CreateAppConnexionAppInitTestCase(TestCase):
 
     # Create an app with bad defs assert that it wont create and will raise and exception
     @patch("app.SPECIFICATION_FILE", value="./swagger/api.spec.yaml")
-    def test_yaml_specification(self, translating_parser, get_engine, app):
+    def test_yaml_specification(self, translating_parser, init_app, app):
         with patch("app.create_app", side_effect=Exception("mocked error")):
             with self.assertRaises(Exception):
                 create_app(RuntimeEnvironment.TEST)


### PR DESCRIPTION
Here's the error log you sent me:
```
_______________________________________________________________________________________________________________________________ CreateAppConnexionAppInitTestCase.test_specification_is_parsed _______________________________________________________________________________________________________________________________

self = <tests.test_unit.CreateAppConnexionAppInitTestCase testMethod=test_specification_is_parsed>, get_engine = <MagicMock name='get_engine' id='140135639016304'>, app = <MagicMock name='FlaskApp' id='140135640196144'>

    def test_specification_is_parsed(self, get_engine, app):
>       create_app(RuntimeEnvironment.TEST)

tests/test_unit.py:482: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
app/__init__.py:252: in create_app
    db.init_app(flask_app)
/home/aarif/.local/share/virtualenvs/insights-host-inventory-oZ_lM_0O/lib64/python3.9/site-packages/flask_sqlalchemy/extension.py:374: in init_app
    engines[key] = self._make_engine(key, options, app)
/home/aarif/.local/share/virtualenvs/insights-host-inventory-oZ_lM_0O/lib64/python3.9/site-packages/flask_sqlalchemy/extension.py:665: in _make_engine
    return sa.engine_from_config(options, prefix="")
/home/aarif/.local/share/virtualenvs/insights-host-inventory-oZ_lM_0O/lib64/python3.9/site-packages/sqlalchemy/engine/create.py:820: in engine_from_config
    return create_engine(url, **options)
<string>:2: in create_engine
    ???
/home/aarif/.local/share/virtualenvs/insights-host-inventory-oZ_lM_0O/lib64/python3.9/site-packages/sqlalchemy/util/deprecations.py:281: in warned
    return fn(*args, **kwargs)  # type: ignore[no-any-return]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

url = <MagicMock name='FlaskApp().app.config.setdefault().update_query_dict()' id='140135637280800'>
```

To help with future debugging, here are the clues that led me to the changes I've suggested:
- In the above error message, you can see that the error is occurring in a function named `_make_engine`.
- If you look at [the source for](https://github.com/pallets-eco/flask-sqlalchemy/blob/main/src/flask_sqlalchemy/extension.py#L665) `_make_engine`, it notes that it was renamed from `create_engine`, which was called by `get_engine` prior to flask-sqlalchemy 3.x.
- The patch in the unit test used to patch `get_engine`.
- The existing tests don't require the flask app to initialize the DB, which is why they patched that function. So, we can just patch `db.init_app` instead.